### PR TITLE
add example docs

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
         },
         {
           label: "Functions",
-          items: ["functions/utility", "functions/record"],
+          items: ["functions/utility", "functions/record", "functions/json"],
         },
         {
           label: "Arrays",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -9,7 +9,8 @@
     "./Either": "./src/Either.ts",
     "./utility": "./src/utility.ts",
     "./function": "./src/utility.ts",
-    "./Array": "./src/Array.ts"
+    "./Array": "./src/Array.ts",
+    "./Json": "./src/Json.ts"
   },
   "publish": {
     "include": [

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -117,6 +117,7 @@ await generate("Arrays", "", [
   "Utils",
 ])
 await generate("Record", "Functions")
+await generate("Json", "Functions")
 
 // Copy the README.md file to src/content/docs/index.md
 const readme = `

--- a/src/Json.ts
+++ b/src/Json.ts
@@ -1,0 +1,54 @@
+import * as Either from "./Either.ts"
+
+/**
+ * Safely parses a JSON string, returning an `Either` with a `SyntaxError` on failure or the parsed value on success.
+ *
+ * @example parse
+ * ```ts
+ * import { parse } from "@jvlk/fp-tsm/Json"
+ * import { expect } from "@std/expect/expect"
+ *
+ * expect(parse('{"a":1}')).toMatchObject({ _tag: "Right", right: { a: 1 } })
+ * expect(parse('a')._tag).toBe("Left")
+ * expect(parse('a')).toMatchObject({ _tag: "Left", left: expect.any(SyntaxError) })
+ * ```
+ */
+export const parse = (s: string): Either.Either<SyntaxError, unknown> => {
+  try {
+    const result = JSON.parse(s)
+    return Either.right(result)
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      return Either.left(err)
+    }
+  }
+  return Either.left(new SyntaxError("Unknown error"))
+}
+
+/**
+ * Safely stringifies a value to JSON, returning an `Either` with a `TypeError` on failure or the JSON string on success.
+ *
+ * @example stringify
+ * ```ts
+ * import { stringify } from "@jvlk/fp-tsm/Json"
+ * import { expect } from "@std/expect/expect"
+ *
+ * expect(stringify({ a: 1 })).toMatchObject({ _tag: "Right", right: '{"a":1}' })
+ *
+ * const circularObj: Record<string, unknown> = {}
+ * circularObj.self = circularObj
+ * expect(stringify(circularObj)._tag).toBe("Left")
+ * expect(stringify(circularObj)).toMatchObject({ _tag: "Left", left: expect.any(TypeError) })
+ * ```
+ */
+export const stringify = (data: unknown): Either.Either<TypeError, string> => {
+  try {
+    const result = JSON.stringify(data)
+    return Either.right(result)
+  } catch (err) {
+    if (err instanceof TypeError) {
+      return Either.left(err)
+    }
+  }
+  return Either.left(new TypeError("Unknown error"))
+}

--- a/src/__tests__/Json.test.ts
+++ b/src/__tests__/Json.test.ts
@@ -1,0 +1,31 @@
+import * as Json from "@jvlk/fp-tsm/Json"
+import { expect } from "@std/expect/expect"
+
+Deno.test("parse", () => {
+  expect(Json.parse('{"a":1}')).toMatchObject({
+    _tag: "Right",
+    right: { a: 1 },
+  })
+
+  expect(Json.parse("a")._tag).toBe("Left")
+  expect(Json.parse("a")).toMatchObject({
+    _tag: "Left",
+    left: expect.any(SyntaxError),
+  })
+})
+
+Deno.test("stringify", () => {
+  expect(Json.stringify({ a: 1 })).toMatchObject({
+    _tag: "Right",
+    right: '{"a":1}',
+  })
+
+  const circularObj: Record<string, unknown> = {}
+  circularObj.self = circularObj
+
+  expect(Json.stringify(circularObj)._tag).toBe("Left")
+  expect(Json.stringify(circularObj)).toMatchObject({
+    _tag: "Left",
+    left: expect.any(TypeError),
+  })
+})


### PR DESCRIPTION
This pull request introduces a new `Json` module that provides functional, type-safe JSON parsing and stringifying utilities, along with updates to documentation generation and module exports to include this new functionality. The main focus is on adding robust error handling for JSON operations using the `Either` type, and ensuring the new module is properly integrated and tested.

**New Json module and integration:**

* Added a new `src/Json.ts` module that exports `parse` and `stringify` functions, each returning an `Either` type to safely handle errors during JSON parsing and stringification. (`[src/Json.tsR1-R54](diffhunk://#diff-ce8d43bf974ef8127c48d25ed9367e1697098b3d0d696c972af433541dc4bcd1R1-R54)`)
* Added comprehensive tests in `src/__tests__/Json.test.ts` to verify correct behavior and error handling for the new `Json` module. (`[src/__tests__/Json.test.tsR1-R31](diffhunk://#diff-21ea95bdd86776c34e346e6e73a7e70573d94eac116e9ffa1d126ebc46de5582R1-R31)`)

**Documentation and configuration updates:**

* Updated documentation generation scripts and navigation: included the new `Json` module in the functions section and ensured docs are generated for it. (`[[1]](diffhunk://#diff-3818393034bb3c29fc82c862fc213f3dab411ee68bc6bf40dca7fca232ccc7a3R120)`, `[[2]](diffhunk://#diff-baf06eda15601b59413c77e1f18884403033204061e6c9408cd9a3bb5bc6e586L22-R22)`)
* Updated module exports in `deno.jsonc` to include the new `Json` module, making it available for import across the codebase. (`[deno.jsoncL12-R13](diffhunk://#diff-81342196266f9373572c759839aa5a9ab9942af52ce56316b4855b3df8db588aL12-R13)`)