### PR TITLE
feat: add number module

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -19,7 +19,13 @@ export default defineConfig({
         },
         {
           label: "Functions",
-          items: ["functions/utility", "functions/record", "functions/json"],
+          items: [
+            "functions/json",
+            "functions/number",
+            "functions/record",
+            "functions/string",
+            "functions/utility",
+          ],
         },
         {
           label: "Arrays",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -11,7 +11,8 @@
     "./function": "./src/utility.ts",
     "./Array": "./src/Array.ts",
     "./Json": "./src/Json.ts",
-    "./string": "./src/string.ts"
+    "./string": "./src/string.ts",
+    "./number": "./src/number.ts"
   },
   "publish": {
     "include": [

--- a/deno.lock
+++ b/deno.lock
@@ -30,6 +30,7 @@
     "jsr:@std/data-structures@^1.0.9": "1.0.9",
     "jsr:@std/expect@*": "1.0.16",
     "jsr:@std/expect@0.221": "0.221.0",
+    "jsr:@std/expect@0.221.0": "0.221.0",
     "jsr:@std/expect@^1.0.16": "1.0.16",
     "jsr:@std/fmt@0.221": "0.221.0",
     "jsr:@std/fmt@0.223": "0.223.0",

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -118,6 +118,8 @@ await generate("Arrays", "", [
 ])
 await generate("Record", "Functions")
 await generate("Json", "Functions")
+await generate("string", "Functions")
+await generate("number", "Functions")
 
 // Copy the README.md file to src/content/docs/index.md
 const readme = `

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * as Array from "./Array.ts"
 export * as Either from "./Either.ts"
 export * as Future from "./Future.ts"
+export * from "./number.ts"
 export * as Option from "./Option.ts"
 export * as Record from "./Record.ts"
 export * from "./utility.ts"

--- a/src/number.ts
+++ b/src/number.ts
@@ -1,0 +1,16 @@
+/**
+ * Checks if a value is a number and not NaN.
+ *
+ * @category Refinements
+ * @example isNumber
+ * ```ts
+ * import { expect } from "jsr:@std/expect"
+ * import { isNumber } from "@jvlk/fp-tsm/number"
+ *
+ * expect(isNumber(123)).toEqual(true)
+ * expect(isNumber(NaN)).toEqual(false)
+ * expect(isNumber("123")).toEqual(false)
+ * ```
+ */
+export const isNumber = (n: unknown): n is number =>
+  typeof n === "number" && !isNaN(n)


### PR DESCRIPTION
This pull request adds a new `number` module with a type guard utility, updates exports and configuration to include this module, and ensures documentation is generated for it. The changes improve the library's support for number-related utilities and integrate them into the build and documentation processes.

**New number utilities:**

* Added a new `isNumber` type guard function in `src/number.ts` to check if a value is a number and not NaN.

**Exports and module configuration:**

* Exported all symbols from the new `number` module in `src/index.ts`.
* Added path mappings for `./number` in `deno.jsonc` to support module resolution.

**Documentation and navigation updates:**

* Updated the documentation generation script to include the new `number` module, ensuring docs are built for it.
* Reordered and expanded the "Functions" navigation in `astro.config.ts` to include `number` and `string` modules, improving documentation structure.